### PR TITLE
Add a Dockerfile so we can build a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# pinned version of the Alpine-tagged 'go' image
+FROM golang:1.13-alpine
+
+# setup directories for the source and working
+RUN mkdir -p /usr/local/src/yj/ /workdir && chown -R nobody /workdir
+
+# copy the yj source to the image
+COPY . /usr/local/src/jy/
+
+# build and compile the jq executable
+RUN cd /usr/local/src/jy && go install
+
+# use a non-privileged user
+USER nobody
+
+# work somewhere where we can write
+WORKDIR /workdir
+
+# set the default entrypoint -- when this container is run, use this command
+ENTRYPOINT [ "yj" ]
+
+# as we specified an entrytrypoint, this is appended as an argument (i.e., `jy --help`)
+CMD [ "--help" ]


### PR DESCRIPTION
This adds a Dockerfile so that we can build an image of yj for use in a
container.  To build:

```sh
docker build -t yj .
```

To run:

```sh
docker run --rm -i yj -yj - < file.yaml > file.json
```