### PR TITLE
Update `pelletier/go-toml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.14
 
 require (
 	github.com/hashicorp/hcl v1.0.0
-	github.com/pelletier/go-toml v1.8.0
+	github.com/pelletier/go-toml v1.9.2
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
-
-replace github.com/pelletier/go-toml => github.com/sclevine/go-toml v1.8.1-0.20200722030155-ed50a274ac56

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/sclevine/go-toml v1.8.1-0.20200722030155-ed50a274ac56 h1:bDa4nJH5C3KScrOCWPDGqqTyRf+kqvTWjU0EL+OZoQY=
-github.com/sclevine/go-toml v1.8.1-0.20200722030155-ed50a274ac56/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.9.2 h1:7NiByeVF4jKSG1lDF3X8LTIkq2/bu+1uYbIm1eS5tzk=
+github.com/pelletier/go-toml v1.9.2/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=


### PR DESCRIPTION
Trying to unblock https://github.com/buildpacks/lifecycle/pull/628. The fork's commit was merged into the mainline module [here](https://github.com/pelletier/go-toml/pull/426).

Signed-off-by: Jesse Brown <jabrown85@gmail.com>