### PR TITLE
Bump library versions to fix security issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/sclevine/yj/v5
 
-go 1.18
+go 1.21
 
 require (
-	github.com/BurntSushi/toml v1.1.0
+	github.com/BurntSushi/toml v1.3.2
 	github.com/hashicorp/hcl v1.0.0
-	gopkg.in/yaml.v3 v3.0.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
-github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Bump YAML and TOML Library Version to latest version.

Fixes this current security issue.

```
Total: 0 (HIGH: 0, CRITICAL: 0)
usr/local/bin/yj (gobinary)
===========================
Total: 1 (HIGH: 1, CRITICAL: 0)
┌──────────────────┬────────────────┬──────────┬────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │         Installed Version          │           Fixed Version           │                       Title                        │
├──────────────────┼────────────────┼──────────┼────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────┤
│ gopkg.in/yaml.v3 │ CVE-2022-28948 │ HIGH     │ fixed  │ v3.0.0-202101071           │ 3.0.0-20220521103104-8f96da9f5d5e              
                  │                                 crash when attempting to deserialize invalid input │
│                  │                │          │        │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-28948         │
└──────────────────┴────────────────┴──────────┴────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────┘
```