### PR TITLE
fix: update deps, go version, and tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,11 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.18
+          go-version: old-stable
       - name: Fmt
         run: test -z $(go fmt ./...)
       - name: Vet

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: old-stable
+          go-version: oldstable
       - name: Fmt
         run: test -z $(go fmt ./...)
       - name: Vet

--- a/convert/yaml.go
+++ b/convert/yaml.go
@@ -3,7 +3,7 @@ package convert
 import (
 	"io"
 
-	goyaml "gopkg.in/yaml.v3"
+	goyaml "go.yaml.in/yaml/v3"
 
 	"github.com/sclevine/yj/v5/yaml"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/sclevine/yj/v5
 
-go 1.21
+go 1.25.10
 
 require (
-	github.com/BurntSushi/toml v1.3.2
+	github.com/BurntSushi/toml v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
-github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/order/map.go
+++ b/order/map.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	goyaml "gopkg.in/yaml.v3"
+	goyaml "go.yaml.in/yaml/v3"
 )
 
 type MapSlice []MapItem

--- a/testdata/case1_out_jt.toml
+++ b/testdata/case1_out_jt.toml
@@ -5,10 +5,10 @@
 "<" = ">"
 "{\"<\":\">\"}" = ">"
 "{\"key\":\"value\"}" = "value"
-Infinity = +inf
+Infinity = inf
 -Infinity = -inf
 NaN = nan
-"{\"Infinity\":\"Infinity\"}" = +inf
+"{\"Infinity\":\"Infinity\"}" = inf
 "{\"-Infinity\":\"-Infinity\"}" = -inf
 "{\"NaN\":\"NaN\"}" = nan
 key-number-list = [0, 1, 1.0, 1.1]

--- a/testdata/case2_out_yt.toml
+++ b/testdata/case2_out_yt.toml
@@ -5,10 +5,10 @@
 "<" = ">"
 "{\"<\":\">\"}" = ">"
 "{\"key\":\"value\"}" = "value"
-Infinity = +inf
+Infinity = inf
 -Infinity = -inf
 NaN = nan
-"{\"Infinity\":\"Infinity\"}" = +inf
+"{\"Infinity\":\"Infinity\"}" = inf
 "{\"-Infinity\":\"-Infinity\"}" = -inf
 "{\"NaN\":\"NaN\"}" = nan
 key-number-list = [0.0, 1.0, 1.0, 1.1]

--- a/testdata/case3_in.toml
+++ b/testdata/case3_in.toml
@@ -9,7 +9,7 @@
 '{"key":"value"}' = "value"
 Infinity = inf
 -Infinity = -inf
-"+Infinity" = +inf
+"+Infinity" = inf
 NaN = nan
 -NaN = -nan
 "+NaN" = +nan

--- a/testdata/case4_out_ct.hcl
+++ b/testdata/case4_out_ct.hcl
@@ -4,13 +4,13 @@
 "1.0" = 1
 "1.1" = 1.1
 "<" = ">"
-Infinity = +inf
+Infinity = inf
 NaN = nan
 key-number-list = [0.0, 1.0, 1.1]
 key-string-list = ["a", "b"]
 "{\"-Infinity\":\"-Infinity\"}" = -inf
 "{\"<\":\">\"}" = ">"
-"{\"Infinity\":\"Infinity\"}" = +inf
+"{\"Infinity\":\"Infinity\"}" = inf
 "{\"NaN\":\"NaN\"}" = nan
 "{\"key\":\"value\"}" = "value"
 

--- a/yaml/decoder.go
+++ b/yaml/decoder.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	goyaml "gopkg.in/yaml.v3"
+	goyaml "go.yaml.in/yaml/v3"
 
 	"github.com/sclevine/yj/v5/order"
 )

--- a/yaml/encoder.go
+++ b/yaml/encoder.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"unicode"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/sclevine/yj/v5/order"
 )

--- a/yaml/json.go
+++ b/yaml/json.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"reflect"
 
-	goyaml "gopkg.in/yaml.v3"
+	goyaml "go.yaml.in/yaml/v3"
 )
 
 type KeyJSON struct {


### PR DESCRIPTION
This PR addresses the following issues:

* Updates the go toolchain from 1.21 (unsupported) to 1.25.10 (the current oldest supported version)
* Updates BurntSushi/toml
* Updates from the no-longer-maintained `gopkg.in/yaml.*` packages to `go.yaml.in/yaml/*`
* Updates the GH workflow to use the latest versions of actions
* Updates the GH workflow to use go version alias `oldstable` instead of `1.18`
* Updates the tests to reflect that the new version of `BurntSushi/toml` outputs `inf` instead of `+inf`